### PR TITLE
Fixes/cmake fetch content

### DIFF
--- a/examples/more/fetch-content/CMakeLists.txt
+++ b/examples/more/fetch-content/CMakeLists.txt
@@ -10,7 +10,9 @@ include(FetchContent)
 # of GIT_REPOSITORY - this is very useful for local iterative development
 # if you are working on the libary and application together
 FetchContent_Declare(
-    bec GIT_REPOSITORY https://github.com/pr0g/bit-field-enum-class.git)
+    bec 
+    GIT_REPOSITORY https://github.com/pr0g/bit-field-enum-class.git
+    GIT_TAG origin/main)
 # utility to setup the downloaded library for use
 FetchContent_MakeAvailable(bec)
 

--- a/examples/more/fetch-content/main.cpp
+++ b/examples/more/fetch-content/main.cpp
@@ -16,7 +16,7 @@ enum class Key
 template<>
 struct bec::EnableBitMaskOperators<Key>
 {
-    static const bool enable = true;
+    static const bool Enable = true;
 };
 
 enum class Team
@@ -33,7 +33,7 @@ enum class Team
 template<>
 struct bec::EnableBitMaskOperators<Team>
 {
-    static const bool enable = true;
+    static const bool Enable = true;
 };
 
 // simple example program using bitfield-enum-class library


### PR DESCRIPTION
2 minor fixes to the `fetch-content` example to make the build ok

> a typo (case error) in main.cpp
> CMake FetchContent_Declare defaults to `origin/master` [ `bit-field-enum-class` is on `origin/main`]