### PR TITLE
Superbuild Example

### DIFF
--- a/examples/core/header-only/application/configure.bat
+++ b/examples/core/header-only/application/configure.bat
@@ -1,4 +1,4 @@
 @echo off
 
-cmake -S . -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=%cd%/../library/install
-cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=%cd%/../library/install
+cmake -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=%cd%/../library/install
+cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=%cd%/../library/install

--- a/examples/core/header-only/application/configure.sh
+++ b/examples/core/header-only/application/configure.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-cmake -S . -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(pwd)/../library/install
-cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=$(pwd)/../library/install
+cmake -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(pwd)/../library/install
+cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=$(pwd)/../library/install

--- a/examples/core/header-only/library/configure.bat
+++ b/examples/core/header-only/library/configure.bat
@@ -1,3 +1,3 @@
 @echo off
 
-cmake -S . -B build -G Ninja -DCMAKE_INSTALL_PREFIX=install
+cmake -B build -G Ninja -DCMAKE_INSTALL_PREFIX=install

--- a/examples/core/header-only/library/configure.sh
+++ b/examples/core/header-only/library/configure.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-cmake -S . -B build -G Ninja -DCMAKE_INSTALL_PREFIX=install
+cmake -B build -G Ninja -DCMAKE_INSTALL_PREFIX=install

--- a/examples/core/shared-export/application/configure.bat
+++ b/examples/core/shared-export/application/configure.bat
@@ -1,4 +1,4 @@
 @echo off
 
-cmake -S . -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=%cd%/../library/install
-cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=%cd%/../library/install
+cmake -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=%cd%/../library/install
+cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=%cd%/../library/install

--- a/examples/core/shared-export/application/configure.sh
+++ b/examples/core/shared-export/application/configure.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-cmake -S . -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(pwd)/../library/install
-cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=$(pwd)/../library/install
+cmake -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(pwd)/../library/install
+cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=$(pwd)/../library/install

--- a/examples/core/shared-export/library/configure.bat
+++ b/examples/core/shared-export/library/configure.bat
@@ -1,4 +1,4 @@
 @echo off
 
-cmake -S . -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=install
-cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=install
+cmake -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=install
+cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=install

--- a/examples/core/shared-export/library/configure.sh
+++ b/examples/core/shared-export/library/configure.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-cmake -S . -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=install
-cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=install
+cmake -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=install
+cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=install

--- a/examples/core/shared/application/configure.bat
+++ b/examples/core/shared/application/configure.bat
@@ -1,4 +1,4 @@
 @echo off
 
-cmake -S . -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=%cd%/../library/install
-cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=DelWithDebInfo -DCMAKE_PREFIX_PATH=%cd%/../library/install
+cmake -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=%cd%/../library/install
+cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=DelWithDebInfo -DCMAKE_PREFIX_PATH=%cd%/../library/install

--- a/examples/core/shared/application/configure.sh
+++ b/examples/core/shared/application/configure.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-cmake -S . -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(pwd)/../library/install
-cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=DelWithDebInfo -DCMAKE_PREFIX_PATH=$(pwd)/../library/install
+cmake -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(pwd)/../library/install
+cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=DelWithDebInfo -DCMAKE_PREFIX_PATH=$(pwd)/../library/install

--- a/examples/core/shared/library/configure.bat
+++ b/examples/core/shared/library/configure.bat
@@ -1,4 +1,4 @@
 @echo off
 
-cmake -S . -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=install
-cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=install
+cmake -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=install
+cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=install

--- a/examples/core/shared/library/configure.sh
+++ b/examples/core/shared/library/configure.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-cmake -S . -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=install
-cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=install
+cmake -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=install
+cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=install

--- a/examples/core/static/application/configure.bat
+++ b/examples/core/static/application/configure.bat
@@ -1,4 +1,4 @@
 @echo off
 
-cmake -S . -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=%cd%/../library/install
-cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=%cd%/../library/install
+cmake -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=%cd%/../library/install
+cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=%cd%/../library/install

--- a/examples/core/static/application/configure.sh
+++ b/examples/core/static/application/configure.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-cmake -S . -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(pwd)/../library/install
-cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=$(pwd)/../library/install
+cmake -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(pwd)/../library/install
+cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=$(pwd)/../library/install

--- a/examples/core/static/library/configure.bat
+++ b/examples/core/static/library/configure.bat
@@ -1,4 +1,4 @@
 @echo off
 
-cmake -S . -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=install
-cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=install
+cmake -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=install
+cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=install

--- a/examples/core/static/library/configure.sh
+++ b/examples/core/static/library/configure.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-cmake -S . -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=install
-cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=install
+cmake -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=install
+cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=install

--- a/examples/more/components/application/configure.bat
+++ b/examples/more/components/application/configure.bat
@@ -1,3 +1,3 @@
 @echo off
 
-cmake -S . -B build -DCMAKE_PREFIX_PATH=%cd%/../library/install
+cmake -B build -DCMAKE_PREFIX_PATH=%cd%/../library/install

--- a/examples/more/components/library/configure.bat
+++ b/examples/more/components/library/configure.bat
@@ -1,3 +1,3 @@
 @echo off
 
-cmake -S . -B build -DCMAKE_INSTALL_PREFIX=install
+cmake -B build -DCMAKE_INSTALL_PREFIX=install

--- a/examples/more/external-project-add/configure.bat
+++ b/examples/more/external-project-add/configure.bat
@@ -1,4 +1,4 @@
 @echo off
 
-cmake -S . -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=%cd%/external/build/debug
-cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=%cd%/external/build/release
+cmake -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=%cd%/external/build/debug
+cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=%cd%/external/build/release

--- a/examples/more/external-project-add/configure.sh
+++ b/examples/more/external-project-add/configure.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-cmake -S . -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(pwd)/external/build/debug
-cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=$(pwd)/external/build/release
+cmake -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(pwd)/external/build/debug
+cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=$(pwd)/external/build/release

--- a/examples/more/external-project-add/external/configure-and-build.bat
+++ b/examples/more/external-project-add/external/configure-and-build.bat
@@ -1,7 +1,7 @@
 @echo off
 
-cmake -S . -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug
-cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
+cmake -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug
+cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
 cmake --build build/debug
 cmake --build build/release

--- a/examples/more/external-project-add/external/configure-and-build.sh
+++ b/examples/more/external-project-add/external/configure-and-build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-cmake -S . -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug
-cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
+cmake -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug
+cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
 cmake --build build/debug
 cmake --build build/release

--- a/examples/more/fetch-content/configure.bat
+++ b/examples/more/fetch-content/configure.bat
@@ -1,4 +1,4 @@
 @echo off
 
-cmake -S . -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug
-cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
+cmake -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug
+cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo

--- a/examples/more/fetch-content/configure.sh
+++ b/examples/more/fetch-content/configure.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-cmake -S . -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug
-cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
+cmake -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug
+cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo

--- a/examples/more/header-only-defines/application/configure.bat
+++ b/examples/more/header-only-defines/application/configure.bat
@@ -1,4 +1,4 @@
 @echo off
 
-cmake -S . -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=%cd%/../library/install
-cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=%cd%/../library/install
+cmake -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=%cd%/../library/install
+cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=%cd%/../library/install

--- a/examples/more/header-only-defines/application/configure.sh
+++ b/examples/more/header-only-defines/application/configure.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-cmake -S . -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(pwd)/../library/install
-cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=$(pwd)/../library/install
+cmake -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(pwd)/../library/install
+cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=$(pwd)/../library/install

--- a/examples/more/header-only-defines/library/configure.bat
+++ b/examples/more/header-only-defines/library/configure.bat
@@ -1,3 +1,3 @@
 @echo off
 
-cmake -S . -B build -G Ninja -DCMAKE_INSTALL_PREFIX=install
+cmake -B build -G Ninja -DCMAKE_INSTALL_PREFIX=install

--- a/examples/more/header-only-defines/library/configure.sh
+++ b/examples/more/header-only-defines/library/configure.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-cmake -S . -B build -G Ninja -DCMAKE_INSTALL_PREFIX=install
+cmake -B build -G Ninja -DCMAKE_INSTALL_PREFIX=install

--- a/examples/more/nested-dependencies/application/configure-build.bat
+++ b/examples/more/nested-dependencies/application/configure-build.bat
@@ -1,4 +1,4 @@
 @echo off
 
-cmake -S . -B build -DCMAKE_PREFIX_PATH=../library/lib-b/install
+cmake -B build -DCMAKE_PREFIX_PATH=../library/lib-b/install
 cmake --build build

--- a/examples/more/nested-dependencies/application/configure-build.sh
+++ b/examples/more/nested-dependencies/application/configure-build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-cmake -S . -B build -DCMAKE_PREFIX_PATH=../library/lib-b/install
+cmake -B build -DCMAKE_PREFIX_PATH=../library/lib-b/install
 cmake --build build

--- a/examples/more/nested-dependencies/library/lib-b/configure-build-install.bat
+++ b/examples/more/nested-dependencies/library/lib-b/configure-build-install.bat
@@ -1,4 +1,4 @@
 @echo off
 
-cmake -S . -B build -DCMAKE_INSTALL_PREFIX=./install
+cmake -B build -DCMAKE_INSTALL_PREFIX=./install
 cmake --build build --target install

--- a/examples/more/nested-dependencies/library/lib-b/configure-build-install.sh
+++ b/examples/more/nested-dependencies/library/lib-b/configure-build-install.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-cmake -S . -B build -DCMAKE_INSTALL_PREFIX=./install
+cmake -B build -DCMAKE_INSTALL_PREFIX=./install
 cmake --build build --target install

--- a/examples/more/static-versioned/application-1.0.0/configure.bat
+++ b/examples/more/static-versioned/application-1.0.0/configure.bat
@@ -1,4 +1,4 @@
 @echo off
 
-cmake -S . -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=%cd%/../install
-cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=%cd%/../install
+cmake -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=%cd%/../install
+cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=%cd%/../install

--- a/examples/more/static-versioned/application-1.0.0/configure.sh
+++ b/examples/more/static-versioned/application-1.0.0/configure.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-cmake -S . -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(pwd)/../install
-cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=$(pwd)/../install
+cmake -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(pwd)/../install
+cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=$(pwd)/../install

--- a/examples/more/static-versioned/application-2.0.0/configure.bat
+++ b/examples/more/static-versioned/application-2.0.0/configure.bat
@@ -1,4 +1,4 @@
 @echo off
 
-cmake -S . -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=%cd%/../install
-cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=%cd%/../install
+cmake -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=%cd%/../install
+cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=%cd%/../install

--- a/examples/more/static-versioned/application-2.0.0/configure.sh
+++ b/examples/more/static-versioned/application-2.0.0/configure.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-cmake -S . -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(pwd)/../install
-cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=$(pwd)/../install
+cmake -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=$(pwd)/../install
+cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=$(pwd)/../install

--- a/examples/more/static-versioned/library-1.0.0/configure.bat
+++ b/examples/more/static-versioned/library-1.0.0/configure.bat
@@ -1,4 +1,4 @@
 @echo off
 
-cmake -S . -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../install
-cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=../install
+cmake -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../install
+cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=../install

--- a/examples/more/static-versioned/library-1.0.0/configure.sh
+++ b/examples/more/static-versioned/library-1.0.0/configure.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-cmake -S . -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../install
-cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=../install
+cmake -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../install
+cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=../install

--- a/examples/more/static-versioned/library-2.0.0/configure.bat
+++ b/examples/more/static-versioned/library-2.0.0/configure.bat
@@ -1,4 +1,4 @@
 @echo off
 
-cmake -S . -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../install
-cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=../install
+cmake -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../install
+cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=../install

--- a/examples/more/static-versioned/library-2.0.0/configure.sh
+++ b/examples/more/static-versioned/library-2.0.0/configure.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-cmake -S . -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../install
-cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=../install
+cmake -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../install
+cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=../install

--- a/examples/more/superbuild/.clang-format
+++ b/examples/more/superbuild/.clang-format
@@ -1,0 +1,36 @@
+---
+AccessModifierOffset: -2
+AlignAfterOpenBracket: AlwaysBreak
+AllowShortFunctionsOnASingleLine: InlineOnly
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakTemplateDeclarations: Yes
+AllowAllArgumentsOnNextLine: true
+BreakBeforeBraces: Custom
+BraceWrapping:
+    AfterNamespace: true
+    AfterStruct: true
+    AfterClass: true
+    AfterEnum: true
+    AfterFunction: true
+    SplitEmptyFunction: true
+ColumnLimit: 80
+IndentWidth: 2
+ContinuationIndentWidth: 2
+ConstructorInitializerIndentWidth: 2
+IndentPPDirectives: None
+PenaltyReturnTypeOnItsOwnLine: 1000000
+PenaltyExcessCharacter: 1000000
+PointerAlignment: Left
+SpaceAfterTemplateKeyword: false
+Standard: c++17
+TabWidth: 2
+Cpp11BracedListStyle: true
+IndentCaseLabels: true
+SortIncludes: true
+IncludeBlocks: Preserve
+FixNamespaceComments: true
+AlignOperands: AlignAfterOperator
+AlignTrailingComments: false
+BreakBeforeBinaryOperators: NonAssignment
+...

--- a/examples/more/superbuild/CMakeLists.txt
+++ b/examples/more/superbuild/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.15)
+
+option(SUPERBUILD "Perform a superbuild (or not)" OFF)
+
+project(superbuild-example LANGUAGES CXX)
+
+if(SUPERBUILD)
+    include(external/CMakeLists.txt)
+    include(superbuild.cmake)
+    return()
+endif()
+
+# normal find_package command (no explicit reference to
+# ExternalProject_Add at all)
+find_package(SDL2 REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME})
+target_sources(${PROJECT_NAME} PRIVATE main.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE SDL2::SDL2-static SDL2::SDL2main)
+
+if(WIN32)
+    # copy the SDL2.dll to the same folder as the executable
+    add_custom_command(
+        TARGET ${PROJECT_NAME}
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:SDL2::SDL2>
+                $<TARGET_FILE_DIR:${PROJECT_NAME}>
+        VERBATIM)
+endif()

--- a/examples/more/superbuild/CMakeLists.txt
+++ b/examples/more/superbuild/CMakeLists.txt
@@ -1,25 +1,38 @@
 cmake_minimum_required(VERSION 3.15)
 
+# option to be passed at configure time to CMake
+# use '-DSUPERBUILD=ON' to enable the superbuild, default is off
 option(SUPERBUILD "Perform a superbuild (or not)" OFF)
 
+# top level project command is the same for a normal build or superbuild
 project(superbuild-example LANGUAGES CXX)
 
+# if superbuild is enabled, we first include the external dependencies
+# CMakeLists.txt file so it's in scope, and then in superbuild.cmake, we
+# depend on the external target (in this case SDL2) in the superbuild of
+# this project. We then halt further processing and process this file again
+# with SUPERBUILD disabled (see superbuild.cmake for details)
 if(SUPERBUILD)
     include(external/CMakeLists.txt)
     include(superbuild.cmake)
     return()
 endif()
 
-# normal find_package command (no explicit reference to
-# ExternalProject_Add at all)
+# normal find_package command
+# note: If we already have SDL2 installed somewhere else, so long as we know
+# where it is (we can use -DCMAKE_PREFIX_PATH to specify the search location)
+# we can skip the whole superbuild step
 find_package(SDL2 REQUIRED CONFIG)
 
+# standard project commands for creating an executable and setting dependencies
 add_executable(${PROJECT_NAME})
 target_sources(${PROJECT_NAME} PRIVATE main.cpp)
 target_link_libraries(${PROJECT_NAME} PRIVATE SDL2::SDL2-static SDL2::SDL2main)
 
+# this is specific to the SDL2 library we're using in this example
+# SDL2.dll needs to be next to the main application .exe when running so this
+# custom command will copy the build artifact to the executable folder
 if(WIN32)
-    # copy the SDL2.dll to the same folder as the executable
     add_custom_command(
         TARGET ${PROJECT_NAME}
         POST_BUILD

--- a/examples/more/superbuild/README.md
+++ b/examples/more/superbuild/README.md
@@ -1,0 +1,14 @@
+# How to setup a superbuild
+
+## Overview
+
+This example is an evolution of [external-project-add](/examples/more/external-project-add/README.md). It takes roughly the same format but adds a new option to build the external library and main application in one step.
+
+The trick is to define a 'pseudo' external project for the repo that uses the local source directory to build. It depends on the required external dependencies to ensure they're downloaded and built first.
+
+This example ensures the external dependencies go to a separate build folder in the external folder (otherwise we might as well use `FetchContent`). It also handles different configurations (Debug/Release etc...), using separate folders to store the intermediate build files. Both are installed to the same folder but use a debug postfix (`d`) to ensure debug and release libraries don't stomp on each other.
+
+## References
+
+- [Sarcasm/cmake-superbuild](https://github.com/Sarcasm/cmake-superbuild) - another simple example of using a superbuild with CMake.
+- [Better support for CMake superbuild pattern](https://youtrack.jetbrains.com/issue/CPP-11484/Better-support-for-CMake-superbuild-pattern) - this question (and attached 'awesome-project' attachment) also has a nice example of using a superbuild.

--- a/examples/more/superbuild/README.md
+++ b/examples/more/superbuild/README.md
@@ -8,6 +8,12 @@ The trick is to define a 'pseudo' external project for the repo that uses the lo
 
 This example ensures the external dependencies go to a separate build folder in the external folder (otherwise we might as well use `FetchContent`). It also handles different configurations (Debug/Release etc...), using separate folders to store the intermediate build files. Both are installed to the same folder but use a debug postfix (`d`) to ensure debug and release libraries don't stomp on each other.
 
+## Instructions
+
+- Run `./configure.sh` (or `configure.bat` on Windows)
+- Run `./build.sh` (or `build.bat` on Windows)
+- Run either `./build/<config>/superbuild-example` (or `build\<config>\superbuild-example.exe` on Windows)
+
 ## References
 
 - [Sarcasm/cmake-superbuild](https://github.com/Sarcasm/cmake-superbuild) - another simple example of using a superbuild with CMake.

--- a/examples/more/superbuild/build.bat
+++ b/examples/more/superbuild/build.bat
@@ -1,0 +1,4 @@
+@echo off
+
+cmake --build build/debug
+cmake --build build/release

--- a/examples/more/superbuild/build.sh
+++ b/examples/more/superbuild/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cmake --build build/debug
+cmake --build build/release

--- a/examples/more/superbuild/configure.bat
+++ b/examples/more/superbuild/configure.bat
@@ -1,0 +1,4 @@
+@echo off
+
+cmake -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DSUPERBUILD=ON
+cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=Release -DSUPERBUILD=ON

--- a/examples/more/superbuild/configure.bat
+++ b/examples/more/superbuild/configure.bat
@@ -1,4 +1,4 @@
 @echo off
 
 cmake -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DSUPERBUILD=ON
-cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=Release -DSUPERBUILD=ON
+cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSUPERBUILD=ON

--- a/examples/more/superbuild/configure.sh
+++ b/examples/more/superbuild/configure.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cmake -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DSUPERBUILD=ON
+cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=Release -DSUPERBUILD=ON

--- a/examples/more/superbuild/configure.sh
+++ b/examples/more/superbuild/configure.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 cmake -B build/debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DSUPERBUILD=ON
-cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=Release -DSUPERBUILD=ON
+cmake -B build/release -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSUPERBUILD=ON

--- a/examples/more/superbuild/external/CMakeLists.txt
+++ b/examples/more/superbuild/external/CMakeLists.txt
@@ -1,12 +1,20 @@
 cmake_minimum_required(VERSION 3.15)
+# handle new policy for url download method
+# see https://cmake.org/cmake/help/latest/policy/CMP0135.html for details
 cmake_policy(SET CMP0135 NEW)
 
+# only bother creating a separate project if we're not
+# building as part of a superbuild
 if(NOT SUPERBUILD)
     project(external)
 endif()
 
 include(ExternalProject)
 
+# handle different build configurations for external dependencies for both
+# single and multi-config generators.
+# this is to ensure different build configurations go to separate internal
+# folders so switching between Debug/Release doesn't cause frequent rebuilds
 get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 if(NOT isMultiConfig)
     if(NOT CMAKE_BUILD_TYPE)
@@ -20,6 +28,9 @@ else()
     set(build_config_arg --config=$<CONFIG>)
 endif()
 
+# when using superbuild, choose a default build folder for the external
+# project(s), otherwise default to the one provided by the user if building
+# from this folder
 if(SUPERBUILD)
     set(PREFIX_DIR ${CMAKE_CURRENT_SOURCE_DIR}/external/build)
 else()

--- a/examples/more/superbuild/external/CMakeLists.txt
+++ b/examples/more/superbuild/external/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.15)
+cmake_policy(SET CMP0135 NEW)
+
+if(NOT SUPERBUILD)
+    project(external)
+endif()
+
+include(ExternalProject)
+
+get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if(NOT isMultiConfig)
+    if(NOT CMAKE_BUILD_TYPE)
+        set(CMAKE_BUILD_TYPE
+            Debug
+            CACHE STRING "" FORCE)
+    endif()
+    set(build_type_dir ${CMAKE_BUILD_TYPE})
+    set(build_type_arg -DCMAKE_BUILD_TYPE=$<CONFIG>)
+else()
+    set(build_config_arg --config=$<CONFIG>)
+endif()
+
+if(SUPERBUILD)
+    set(PREFIX_DIR ${CMAKE_CURRENT_SOURCE_DIR}/external/build)
+else()
+    set(PREFIX_DIR ${CMAKE_CURRENT_BINARY_DIR})
+endif()
+
+# download, configure, build and install the dependency
+# note: The install location is set to the build folder
+ExternalProject_Add(
+    SDL2
+    URL https://github.com/libsdl-org/SDL/releases/download/release-2.24.1/SDL2-2.24.1.tar.gz
+    URL_HASH MD5=10bad2a286f155565edc611f41345de1
+    PREFIX ${PREFIX_DIR}
+    BINARY_DIR ${PREFIX_DIR}/src/SDL2-build/${build_type_dir}
+    CMAKE_ARGS ${build_type_arg} -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+    BUILD_COMMAND cmake --build <BINARY_DIR> ${build_config_arg}
+    INSTALL_COMMAND cmake --build <BINARY_DIR> --target install
+                    ${build_config_arg})

--- a/examples/more/superbuild/external/optional-configure-and-build.bat
+++ b/examples/more/superbuild/external/optional-configure-and-build.bat
@@ -1,0 +1,7 @@
+@echo off
+
+cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug
+cmake --build build
+
+cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+cmake --build build

--- a/examples/more/superbuild/external/optional-configure-and-build.bat
+++ b/examples/more/superbuild/external/optional-configure-and-build.bat
@@ -1,5 +1,8 @@
 @echo off
 
+REM note: this is not required to run if -DSUPERBUILD=ON is set from the
+REM main project
+
 cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug
 cmake --build build
 

--- a/examples/more/superbuild/external/optional-configure-and-build.bat
+++ b/examples/more/superbuild/external/optional-configure-and-build.bat
@@ -3,5 +3,5 @@
 cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug
 cmake --build build
 
-cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
 cmake --build build

--- a/examples/more/superbuild/external/optional-configure-and-build.sh
+++ b/examples/more/superbuild/external/optional-configure-and-build.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# note: this is not required to run if -DSUPERBUILD=ON is set from the
+# main project
+
 cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug
 cmake --build build
 

--- a/examples/more/superbuild/external/optional-configure-and-build.sh
+++ b/examples/more/superbuild/external/optional-configure-and-build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug
+cmake --build build
+
+cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+cmake --build build

--- a/examples/more/superbuild/external/optional-configure-and-build.sh
+++ b/examples/more/superbuild/external/optional-configure-and-build.sh
@@ -3,5 +3,5 @@
 cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug
 cmake --build build
 
-cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo
 cmake --build build

--- a/examples/more/superbuild/main.cpp
+++ b/examples/more/superbuild/main.cpp
@@ -1,0 +1,34 @@
+#include <SDL.h>
+
+int main(int argc, char** argv)
+{
+  if (SDL_Init(SDL_INIT_VIDEO) < 0) {
+    printf("SDL could not initialize. SDL_Error: %s\n", SDL_GetError());
+    return 1;
+  }
+
+  const int width = 800;
+  const int height = 600;
+  SDL_Window* window = SDL_CreateWindow(
+    argv[0], SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height,
+    SDL_WINDOW_SHOWN);
+
+  if (window == nullptr) {
+    printf("Window could not be created. SDL_Error: %s\n", SDL_GetError());
+    return 1;
+  }
+
+  for (bool running = true; running;) {
+    for (SDL_Event currentEvent; SDL_PollEvent(&currentEvent) != 0;) {
+      if (currentEvent.type == SDL_QUIT) {
+        running = false;
+        break;
+      }
+    }
+  }
+
+  SDL_DestroyWindow(window);
+  SDL_Quit();
+
+  return 0;
+}

--- a/examples/more/superbuild/main.cpp
+++ b/examples/more/superbuild/main.cpp
@@ -1,5 +1,7 @@
 #include <SDL.h>
 
+#include <cstdio>
+
 int main(int argc, char** argv)
 {
   if (SDL_Init(SDL_INIT_VIDEO) < 0) {
@@ -18,6 +20,14 @@ int main(int argc, char** argv)
     return 1;
   }
 
+  SDL_Renderer* renderer = SDL_CreateRenderer(
+    window, -1, SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
+  
+  if (renderer == nullptr) {
+    printf("Renderer could not be created. SDL_Error: %s\n", SDL_GetError());
+    return 1;
+  }
+
   for (bool running = true; running;) {
     for (SDL_Event currentEvent; SDL_PollEvent(&currentEvent) != 0;) {
       if (currentEvent.type == SDL_QUIT) {
@@ -25,8 +35,13 @@ int main(int argc, char** argv)
         break;
       }
     }
+    // cornflower blue
+    SDL_SetRenderDrawColor(renderer, 100, 149, 237, 255);
+    SDL_RenderClear(renderer);
+    SDL_RenderPresent(renderer);
   }
 
+  SDL_DestroyRenderer(renderer);
   SDL_DestroyWindow(window);
   SDL_Quit();
 

--- a/examples/more/superbuild/superbuild.cmake
+++ b/examples/more/superbuild/superbuild.cmake
@@ -1,10 +1,24 @@
+# note: external/CMakeLists.txt is included ahead of this in the root
+# CMakeLists.txt file which makes SDL2, ${build_type_arg} and
+# ${build_config_arg} visible
+
+# create an external project of our local project
 ExternalProject_Add(
-    ${CMAKE_PROJECT_NAME}_superbuild
+    ${PROJECT_NAME}_superbuild
+    # set the dependencies required by our project to ensure they're built
     DEPENDS SDL2
+    # set the source location to be that of our local project
     SOURCE_DIR ${PROJECT_SOURCE_DIR}
     BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}
     INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}
     CMAKE_ARGS -DCMAKE_PREFIX_PATH=${CMAKE_CURRENT_SOURCE_DIR}/external/build
-               -DSUPERBUILD=OFF ${build_type_arg}
+               # disable SUPERBUILD (as we're effectively calling the top level
+               # CMakeLists.txt file recursively)
+               -DSUPERBUILD=OFF
+               ${build_type_arg}
+    # ${build_type_arg} and ${build_config_arg} come from the external project
+    # CMakeLists.txt file and correspond to the build configuration for single
+    # and multi-config generators
     BUILD_COMMAND cmake --build <BINARY_DIR> ${build_config_arg}
+    # (optional) disable install command for application
     INSTALL_COMMAND "")

--- a/examples/more/superbuild/superbuild.cmake
+++ b/examples/more/superbuild/superbuild.cmake
@@ -1,0 +1,10 @@
+ExternalProject_Add(
+    ${CMAKE_PROJECT_NAME}_superbuild
+    DEPENDS SDL2
+    SOURCE_DIR ${PROJECT_SOURCE_DIR}
+    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}
+    INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}
+    CMAKE_ARGS -DCMAKE_PREFIX_PATH=${CMAKE_CURRENT_SOURCE_DIR}/external/build
+               -DSUPERBUILD=OFF ${build_type_arg}
+    BUILD_COMMAND cmake --build <BINARY_DIR> ${build_config_arg}
+    INSTALL_COMMAND "")


### PR DESCRIPTION
- Add superbuild example to `examples/more` folder.
- Tidy up existing `.bat/.sh` scripts by removing redundant `-S .` command line argument for CMake configure commands (the local directory is the default anyway).